### PR TITLE
SUMM-456: Replaced sch_node_child_next with sch_node_next_sibling

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -42,9 +42,9 @@ void sch_free (sch_instance * schema);
 sch_node *sch_lookup (sch_instance * schema, const char *path);
 char *sch_dump_xml (sch_instance * schema);
 
-sch_node *sch_node_child (sch_node * parent, const char *name);
+sch_node *sch_node_child (sch_node *parent, const char *name);
 sch_node *sch_node_child_first (sch_node * parent);
-sch_node *sch_node_child_next (sch_node * parent, sch_node * node);
+sch_node *sch_node_next_sibling (sch_node * node);
 
 char *sch_name (sch_node * node);
 char *sch_path (sch_node * node);

--- a/schema.c
+++ b/schema.c
@@ -416,10 +416,10 @@ sch_node_child (sch_node * parent, const char *child)
 }
 
 sch_node *
-sch_node_child_next (sch_node * parent, sch_node * node)
+sch_node_child_first (sch_node *parent)
 {
     xmlNode *xml = (xmlNode *) parent;
-    xmlNode *n = node ? ((xmlNode *) node)->next : xml->children;
+    xmlNode *n = xml->children;
 
     while (n)
     {
@@ -431,9 +431,17 @@ sch_node_child_next (sch_node * parent, sch_node * node)
 }
 
 sch_node *
-sch_node_child_first (sch_node * parent)
+sch_node_next_sibling (sch_node *node)
 {
-    return sch_node_child_next (parent, NULL);
+    xmlNode *n = ((xmlNode *) node)->next;
+
+    while (n)
+    {
+        if (n->type == XML_ELEMENT_NODE && n->name[0] == 'N')
+            break;
+        n = n->next;
+    }
+    return n;
 }
 
 char *


### PR DESCRIPTION
Parent is no longer required to get next schema node.