### PR TITLE
SUMM-522: Support augmented models

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -45,9 +45,10 @@ char *sch_dump_xml (sch_instance * schema);
 sch_node *sch_node_child (sch_node *parent, const char *name);
 sch_node *sch_node_child_first (sch_node * parent);
 sch_node *sch_node_next_sibling (sch_node * node);
+sch_node *sch_preorder_next (sch_node *current, sch_node *root);
 
 char *sch_name (sch_node * node);
-char *sch_model (sch_node * node);
+char *sch_model (sch_node * node, bool ignore_ancestors);
 char *sch_organization (sch_node * node);
 char *sch_version (sch_node * node);
 char *sch_path (sch_node * node);


### PR DESCRIPTION
Augmented model data was previously overwritten on load. Now, the model
attributes are added to the root node of all branches in a model that
are not already in the schema.

Calling sch_model on a node shared between models will only return the
first model used to load it. To determine if the node is in another
model, check for that model in the subtree.
Calling sch_model with ignore_ancestors set to true checks if the given
node has model data attributes.

Additionally added a preorder traversal function for sch_node objects.