### PR TITLE
Implement get-config

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -71,6 +71,7 @@ typedef enum
     SCH_F_JSON_ARRAYS = 0x4,
     SCH_F_JSON_TYPES = 0x8,
     SCH_F_XPATH = 0x10,
+    SCH_F_CONFIG = 0x20,
 } sch_flags;
 GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char *path, int flags);
 #ifdef APTERYX_XML_LIBXML2


### PR DESCRIPTION
Allow for get to be either config only or all data. Don't add non-config
nodes to tree if getting config only.

Note that API has not changed, just added a flag.