### PR TITLE
merge_nodes: Use xmlAddChild instead of setting children

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -168,8 +168,8 @@ add_module_info_to_node(xmlNode * node)
 }
 
 /* Merge nodes from a new tree to the original tree */
-static xmlNode *
-merge_nodes (xmlNode * orig, xmlNode * new, int depth)
+static void
+merge_nodes (xmlNode * parent, xmlNode * orig, xmlNode * new, int depth)
 {
     xmlNode *n;
     xmlNode *o;
@@ -187,7 +187,7 @@ merge_nodes (xmlNode * orig, xmlNode * new, int depth)
         if (o)
         {
             /* Already exists - merge in the children */
-            o->children = merge_nodes (o->children, n->children, depth + 1);
+            merge_nodes (o, o->children, n->children, depth + 1);
         }
         else
         {
@@ -209,18 +209,10 @@ merge_nodes (xmlNode * orig, xmlNode * new, int depth)
                 }
             }
 
-            /* Add as a sibling to the existing tree node */
-            if (orig)
-            {
-                xmlAddSibling (orig, o);
-            }
-            else
-            {
-                orig = o;
-            }
+            /* Add as a child to the existing tree node */
+            xmlAddChild (parent, o);
         }
     }
-    return orig;
 }
 
 /* Remove unwanted nodes and attributes from a parsed tree */
@@ -271,8 +263,8 @@ sch_load (const char *path)
             continue;
         }
         cleanup_nodes (xmlDocGetRootElement (new)->children);
-        xmlDocGetRootElement (doc)->children = merge_nodes (xmlDocGetRootElement (doc)->children,
-                                                            xmlDocGetRootElement (new)->children, 0);
+        merge_nodes (xmlDocGetRootElement (doc), xmlDocGetRootElement (doc)->children,
+                     xmlDocGetRootElement (new)->children, 0);
         xmlFreeDoc (new);
     }
     g_list_free_full (files, free);


### PR DESCRIPTION
With newer releases of libxml2, merge_nodes()'s direct setting of the xmlNode->children resulted in the tree not being formed in the way libxml2 expected, resulting in the xmlCopyDoc() of sch_dump_xml() segfaulting while performing a copy of nodes.

To resolve this, the parent node is now passed to merge_nodes(), allowing the use xmlAddChild() instead of a combination of xmlAddSibiling() and direct setting of xmlNode->children.


Segfault seen with apteryx-xml-2.0.11 and libxml2-v2.10.3:
#0 xmlStaticCopyNode (node=0x12cd3b600, doc=0xffe003d140, parent=0xffe003d140, extended=<optimized out>) at tree.c:4438
#1 0x000000ffeee66364 in xmlStaticCopyNodeList (node=0x12cd3b600, doc=0xffe003d140, parent=0xffe003d140) at tree.c:4481
#2 0x000000ffeee66974 in xmlCopyDoc (doc=0x12cd03a00, recursive=<optimized out>) at tree.c:4699
#3 0x000000ffeef96108 in sch_dump_xml (schema=<optimized out>) at schema.c:361 

