### PR TITLE
sch_gnode_to_json: Handle NULL values

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -1686,7 +1686,7 @@ _sch_gnode_to_json (sch_instance * instance, sch_node * schema, GNode * node, in
     }
     else if (APTERYX_HAS_VALUE (node))
     {
-        char *value = strdup (APTERYX_VALUE (node));
+        char *value = strdup (APTERYX_VALUE (node) ? APTERYX_VALUE (node) : "");
         if (flags & SCH_F_JSON_TYPES)
         {
             value = sch_translate_to (schema, value);


### PR DESCRIPTION
An apteryx_provide callback may return NULL, resulting in the tree returned by apteryx_get_tree() containing a NULL value. sch_gnode_to_json currently does not handle this and attempts to strdup(NULL), resulting in a segfault.

Resolve this by handling this case, and replacing the NULL with an empty string.