### PR TITLE
sch_gnode_to_json: Use values for leaf list array

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -1648,11 +1648,11 @@ _sch_gnode_to_json (sch_instance * instance, sch_node * schema, GNode * node, in
         data = json_array ();
         apteryx_sort_children (node, g_strcmp0);
 
-        DEBUG (flags, "%*s%s[", depth * 2, " ", APTERYX_NAME (node));
+        DEBUG (flags, "%*s%s[", depth * 2, " ", APTERYX_VALUE (node));
         for (GNode * child = node->children; child; child = child->next)
         {
-            DEBUG (flags, "%s%s", APTERYX_NAME (child), child->next ? ", " : "");
-            json_array_append_new (data, json_string ((const char* ) APTERYX_NAME (child)));
+            DEBUG (flags, "%s%s", APTERYX_VALUE (child), child->next ? ", " : "");
+            json_array_append_new (data, json_string ((const char* ) APTERYX_VALUE (child)));
         }
         DEBUG (flags, "]\n");
     }


### PR DESCRIPTION
When the SCH_F_JSON_ARRAYS flag is enabled, sch_gnode_to_json() will encode a leaf list of nodes as a JSON array of the node names.

Typically, the name and value of leaf list nodes are identical, however in some cases they are not, as the name has addtional restrictions on what characters it can contain. For example, consider a leaf list of IP addresses with mask lens:

  subnets/192.168.0.1_24  192.168.0.1/24
  subnets/192.168.1.1_24  192.168.1.1/24
  subnets/192.168.2.1_24  192.168.2.1/24

This results in a JSON array of ["192.168.0.1_24", "192.168.1.1_24", ...] which is not particularly useful for the API client as the client was expecting / as the mask len separator.

To resolve this, use the node values instead of node names when encoding a leaf list as a JSON array. For the above example this results in: ["192.168.0.1/24", "192.168.1.1/24", ...]

This matches the behaviour of pre-apteryx-xml appweb-apteryxHandler.