### PR TITLE
schema: add support for Netconf operations

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -43,6 +43,8 @@ typedef struct _sch_loaded_model
     char *version;
 } sch_loaded_model;
 
+typedef void * sch_xml_to_gnode_parms;
+
 /* Schema */
 typedef void sch_instance;
 typedef void sch_node;
@@ -102,7 +104,14 @@ GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char
 #ifdef APTERYX_XML_LIBXML2
 #include <libxml/tree.h>
 xmlNode *sch_gnode_to_xml (sch_instance * instance, sch_node * schema, GNode * node, int flags);
-GNode *sch_xml_to_gnode (sch_instance * instance, sch_node * schema, xmlNode * xml, int flags);
+sch_xml_to_gnode_parms sch_xml_to_gnode (sch_instance * instance, sch_node * schema, xmlNode * xml, int flags, char * def_op, bool is_edit);
+GNode *sch_parm_tree (sch_xml_to_gnode_parms parms);
+char *sch_parm_error_tag (sch_xml_to_gnode_parms parms);
+GList *sch_parm_deletes (sch_xml_to_gnode_parms parms);
+GList *sch_parm_removes (sch_xml_to_gnode_parms parms);
+GList *sch_parm_creates (sch_xml_to_gnode_parms parms);
+GList *sch_parm_replaces (sch_xml_to_gnode_parms parms);
+void sch_parm_free (sch_xml_to_gnode_parms parms);
 #endif
 #ifdef APTERYX_XML_JSON
 #include <jansson.h>


### PR DESCRIPTION
Parsing of XML content for get and edit-config is enhanced to support operations encountered in the message element. This supports the semantics of the Netconf operations delete, replace, create and remove.