### PR TITLE
Fix heap-use-after-free errror

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -2267,7 +2267,7 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, xmlNs *ns
         attr = (char *) xmlGetProp (xml, BAD_CAST key);
         if (attr)
         {
-            node = APTERYX_NODE (node, attr);
+            node = APTERYX_NODE (node, g_strdup (attr));
             DEBUG (_parms->in_flags, "%*s%s\n", depth * 2, " ", APTERYX_NAME (node));
             if (!(_parms->in_flags & SCH_F_STRIP_KEY) || xmlFirstElementChild (xml))
             {

--- a/schema.c
+++ b/schema.c
@@ -2274,7 +2274,7 @@ _sch_xml_to_gnode (_sch_xml_to_gnode_parms *_parms, sch_node * schema, xmlNs *ns
                 APTERYX_NODE (node, g_strdup (key));
                 DEBUG (_parms->in_flags, "%*s%s\n", (depth + 1) * 2, " ", key);
             }
-            key_value = attr;
+            key_value = g_strdup (attr);
         }
         else if (xmlFirstElementChild (xml) &&
                  g_strcmp0 ((const char *) xmlFirstElementChild (xml)->name, key) == 0 &&


### PR DESCRIPTION
Fix heap-use-after-free (double-free) error encountered while executing
the following apteryx-netconf unit tests:

- `tests/test_get_subtree.py::test_get_subtree_select_attr_named_element`
- `tests/test_get_subtree.py::test_get_subtree_select_attr_named_only`