### PR TITLE
Support using a subset of the available XML models for Netconf

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -49,6 +49,8 @@ typedef void * sch_xml_to_gnode_parms;
 typedef struct _sch_instance sch_instance;
 typedef void sch_node;
 sch_instance *sch_load (const char *path);
+sch_instance *sch_load_with_model_list_filename (const char *path,
+                                                 const char *model_list_filename);
 void sch_free (sch_instance * instance);
 sch_node *sch_lookup (sch_instance * instance, const char *path);
 char *sch_dump_xml (sch_instance * instance);


### PR DESCRIPTION
This changes allows a configuration file to be specified that contains a list of the model names to be loaded at start up. This gives finer control of the models loaded by protocols such as Netconf.