### PR TITLE
Add support for reporting YANG model features and deviations

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -43,6 +43,8 @@ typedef struct _sch_loaded_model
     char *model;
     char *organization;
     char *version;
+    char *features;
+    char *deviations;
 } sch_loaded_model;
 
 typedef void * sch_xml_to_gnode_parms;

--- a/pyang-apteryx-xml.py
+++ b/pyang-apteryx-xml.py
@@ -5,6 +5,7 @@ Output paths in Apteryx XML file format
 """
 import io
 import sys
+import os
 import optparse
 import xml.etree.ElementTree as etree
 from collections import OrderedDict
@@ -178,6 +179,15 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
         rev = module.search_one('revision')
         if rev is not None:
             root.set("version", rev.arg)
+        if ctx.opts.features:
+            features_string = ','.join(ctx.opts.features)
+            root.set("features", features_string)
+        if ctx.opts.deviations:
+            lst = []
+            for x in ctx.opts.deviations:
+                lst.append(os.path.splitext(x)[0])
+            deviations_string = ','.join(lst)
+            root.set("deviations", deviations_string)
 
         # Add any included/imported models
         for m in module.search("include"):


### PR DESCRIPTION
This change parses the input XML files and records any model features and deviations set. This information is used by netconf and restconf to set a models capabilities or ietf_yang_library fields.