### PR TITLE
Refactor native and namespace matching

### DIFF
--- a/models/namespace.map
+++ b/models/namespace.map
@@ -1,2 +1,3 @@
 #<namespace> <root node>
 http://test.com/ns/yang/testing-2 /t2:test
+http://test.com/ns/yang/testing-3 /t3:test

--- a/models/test3:test3.xml
+++ b/models/test3:test3.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<MODULE xmlns="http://test.com/ns/yang/testing-3"
+        xmlns:t3="http://test.com/ns/yang/testing-3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd"
+        model="testing-3" organization="Test 3 Ltd" version="2023-03-01">
+  <NODE name="test3" help="This is a test node in the testing-3 namespace">
+    <NODE name="state" help="State">
+      <NODE name="cost" mode="r" help="a string"/>
+    </NODE>
+  </NODE>
+</MODULE>

--- a/models/test3:x.xml
+++ b/models/test3:x.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<MODULE xmlns="https://github.com/alliedtelesis/apteryx"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd">
+  <NODE name="test3" help="This is a test node in the apteryx namespace">
+    <NODE name="state" help="State">
+      <NODE name="age" mode="r" help="a string"/>
+    </NODE>
+  </NODE>
+</MODULE>


### PR DESCRIPTION
Now correctly matches default apteryx namespaces
as native.

Add test models for restconf unit tests.