### PR TITLE
Fix memory issues creating error message information

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -2729,8 +2729,8 @@ _operation_ok (_sch_xml_to_gnode_parms *_parms, xmlNode *xml, char *curr_op, cha
         {
             _parms->out_error.tag = NC_ERR_TAG_BAD_ATTR;
             _parms->out_error.type = NC_ERR_TYPE_PROTOCOL;
-            g_hash_table_insert (_parms->out_error.info, "bad-element", "operation");
-            g_hash_table_insert (_parms->out_error.info, "bad-attribute", attr);
+            g_hash_table_insert (_parms->out_error.info, "bad-element", g_strdup ("operation"));
+            g_hash_table_insert (_parms->out_error.info, "bad-attribute", g_strdup (attr));
 
             return false;
         }
@@ -2761,8 +2761,8 @@ _operation_ok (_sch_xml_to_gnode_parms *_parms, xmlNode *xml, char *curr_op, cha
             g_free (attr);
             _parms->out_error.tag = NC_ERR_TAG_UNKNOWN_ATTR;
             _parms->out_error.type = NC_ERR_TYPE_PROTOCOL;
-            g_hash_table_insert (_parms->out_error.info, "bad-element", "operation");
-            g_hash_table_insert (_parms->out_error.info, "bad-attribute", attr);
+            g_hash_table_insert (_parms->out_error.info, "bad-element", g_strdup ("operation"));
+            g_hash_table_insert (_parms->out_error.info, "bad-attribute", g_strdup (attr));
             return false;
         }
         g_free (attr);


### PR DESCRIPTION
When adding info items to the hash table, be aware that the cleanup will free the values (but not the keys). Static strings and values that are freed elsewhere cannot be added as is.