### PR TITLE
Tidy up a query tree after a query finds no data

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -109,6 +109,7 @@ GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char
 bool sch_query_to_gnode (sch_instance * instance, sch_node * schema, GNode *parent, const char * query, int flags, int *rflags);
 bool sch_traverse_tree (sch_instance * instance, sch_node * schema, GNode * node, int flags);
 GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char * path, int flags); //DEPRECATED
+GNode *sch_gnode_remove_empty_nodes (GNode *node);
 
 /*
  * Netconf error handling

--- a/schema.c
+++ b/schema.c
@@ -3806,3 +3806,28 @@ sch_json_to_gnode (sch_instance * instance, sch_node * schema, json_t * json, in
     }
     return root;
 }
+
+GNode *
+_sch_gnode_remove_empty_nodes (GNode *node)
+{
+    if (node)
+    {
+        if (!node->data)
+        {
+            g_node_destroy (node);
+            return NULL;
+        }
+
+        for (GNode *child = node->children; child; child = child->next)
+        {
+            _sch_gnode_remove_empty_nodes (child);
+        }
+    }
+    return node;
+}
+
+GNode *
+sch_gnode_remove_empty_nodes (GNode *node)
+{
+    return _sch_gnode_remove_empty_nodes (node);
+}


### PR DESCRIPTION
During the process of call apteryx_query, the query tree can become augmented with additional nodes. If the query fails these nodes contain no data. A new routine has been added to remove these empty nodes from a query tree, before the query tree can be used again.