### PR TITLE
Use basename when converting deviation path to name

### DIFF
--- a/pyang-apteryx-xml.py
+++ b/pyang-apteryx-xml.py
@@ -185,7 +185,7 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
         if ctx.opts.deviations:
             lst = []
             for x in ctx.opts.deviations:
-                lst.append(os.path.splitext(x)[0])
+                lst.append(os.path.basename(os.path.splitext(x)[0]))
             deviations_string = ','.join(lst)
             root.set("deviations", deviations_string)
 


### PR DESCRIPTION
It is possible for the deviation argument to receive a path instead of a file name, such as --deviation=foo/ietf-network-deviation.yang.

To handle this correctly, the directory components are now removed using basename when converting the argument to a module name.