### PR TITLE
Correctly add missing values when adding defaults

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -3345,7 +3345,7 @@ _sch_traverse_nodes (sch_node * schema, GNode * parent, int flags)
                 /* Add missing values */
                 else if (!APTERYX_HAS_VALUE (child))
                 {
-                    APTERYX_NODE (child->children, value);
+                    APTERYX_NODE (child, value);
                     value = NULL;
                 }
                 /* Replace empty value */


### PR DESCRIPTION
Previously the tree passed in always had empty nodes for values due to apteryx_query behaviour. Now it
is possible for the value to be NULL and this code is hit but did not work. It has been fixed.