### PR TITLE
Add support for NETCONF XPATH 1.0

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -66,6 +66,7 @@ sch_node *sch_node_child (sch_node *parent, const char *name);
 sch_node *sch_node_child_first (sch_node * parent);
 sch_node *sch_node_next_sibling (sch_node * node);
 sch_node *sch_preorder_next (sch_node *current, sch_node *root);
+sch_node *sch_get_root_schema (sch_instance * instance);
 
 char *sch_name (sch_node * node);
 char *sch_model (sch_node * node, bool ignore_ancestors);
@@ -86,6 +87,8 @@ bool sch_is_proxy (sch_node * node);
 char *sch_translate_to (sch_node * node, char *value);
 char *sch_translate_from (sch_node * node, char *value);
 bool sch_validate_pattern (sch_node * node, const char *value);
+gboolean sch_match_name (const char *s1, const char *s2);
+bool sch_ns_match (sch_node *node, void *ns);
 
 /* Data translation/manipulation */
 typedef enum

--- a/schema.c
+++ b/schema.c
@@ -767,8 +767,8 @@ sch_get_loaded_models (sch_instance * instance)
     return instance->models_list;
 }
 
-static gboolean
-match_name (const char *s1, const char *s2)
+gboolean
+sch_match_name (const char *s1, const char *s2)
 {
     char c1, c2;
     do
@@ -943,7 +943,7 @@ sch_dump_xml (sch_instance * instance)
 }
 
 static bool
-sch_ns_match (xmlNode *node, xmlNs *ns)
+_sch_ns_match (xmlNode *node, xmlNs *ns)
 {
     sch_instance *instance = node->doc->_private;
 
@@ -970,6 +970,18 @@ sch_ns_match (xmlNode *node, xmlNs *ns)
 
     /* No match */
     return false;
+}
+
+bool
+sch_ns_match (sch_node *node, void *ns)
+{
+    return _sch_ns_match (node, ns);
+}
+
+sch_node *
+sch_get_root_schema (sch_instance * instance)
+{
+    return (instance ? xmlDocGetRootElement (instance->doc) : NULL);
 }
 
 static xmlNs *
@@ -1079,7 +1091,7 @@ lookup_node (sch_instance *instance, xmlNs *ns, xmlNode *node, const char *path)
             if (lk)
                 key[lk - key] = '\0';
         }
-        if (name && (name[0] == '*' || match_name (name, key)) && sch_ns_match (n, ns))
+        if (name && (name[0] == '*' || sch_match_name (name, key)) && _sch_ns_match (n, ns))
         {
             free (key);
             if (path)
@@ -1130,7 +1142,7 @@ _sch_node_child (xmlNs *ns, sch_node * parent, const char *child)
         if (n->type == XML_ELEMENT_NODE && n->name[0] == 'N')
         {
             char *name = (char *) xmlGetProp (n, (xmlChar *) "name");
-            if (name && (name[0] == '*' || match_name (name, child)) && sch_ns_match (n, ns))
+            if (name && (name[0] == '*' || sch_match_name (name, child)) && _sch_ns_match (n, ns))
             {
                 xmlFree (name);
                 break;
@@ -1155,7 +1167,7 @@ _sch_node_find_name (xmlNs *ns, sch_node * parent, const char *path_name, GList 
         if (n->type == XML_ELEMENT_NODE && n->name[0] == 'N')
         {
             char *name = (char *) xmlGetProp (n, (xmlChar *) "name");
-            if (match_name (name, path_name) && sch_ns_match (n, ns))
+            if (sch_match_name (name, path_name) && _sch_ns_match (n, ns))
             {
                 xmlFree (name);
                 found = true;


### PR DESCRIPTION
Some functions have been added to support XPATH in NETCONF. In particular two new namespace routines have been added to look up a root path based on a namespace and to find a namespace based on a root path name.

A function was added to support the reporting of list key values in an XPATH result tree. This is done by making sure such nodes are present in the hash table of nodes to report in the XPATH result tree.