### PR TITLE
Add a routine to merge two GNode n_ary trees together

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -3931,7 +3931,8 @@ _sch_traverse_nodes (sch_node * schema, GNode * parent, int flags, int depth, in
         }
         else if (flags & SCH_F_ADD_DEFAULTS)
         {
-            if (!(flags & SCH_F_FILTER_RDEPTH) || (depth >= rdepth))
+            if (!(flags & SCH_F_FILTER_RDEPTH) || (depth >= rdepth ||
+                (depth == rdepth - 1 && child && g_strcmp0(name, APTERYX_NAME (child)) == 0)))
             {
                 /* We do not need to do anything at all if this leaf does not have a default */
                 char *value = sch_translate_from (schema, sch_default_value (schema));


### PR DESCRIPTION
The input trees need to be highly overlapping. This function is used by netconf to merge two GNode trees which are generated from filling in a search tree with added default values and from the initial search query with added default values.

The _sch_traverse_nodes routine has been slightly modified to allow netconf to add defaults for an input tree that is a query.