### PR TITLE
Improve the translation of models

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -119,7 +119,8 @@ bool sch_traverse_tree (sch_instance * instance, sch_node * schema, GNode * node
 GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char * path, int flags); //DEPRECATED
 GNode *sch_translate_input (sch_instance * instance, GNode *node, int flags,
                             void **xlat_data, sch_node **rschema);
-GNode *sch_translate_output (sch_instance * instance, GNode *node, int flags, void *xlat_data);
+GNode *sch_translate_output (sch_instance * instance, GNode *node, GNode *query, int flags, void *xlat_data);
+GNode *sch_translate_copy_query (GNode *query);
 
 /*
  * Netconf error handling

--- a/models/xlat_test.xlat
+++ b/models/xlat_test.xlat
@@ -28,7 +28,7 @@ end
 return {
     {
         external = '/xlat-test/xlat-animals',
-        internal = '/test/animals/animal',
+        internal = '/test/animals',
     },
     {
         external = '/xlat-test/xlat-animals/xlat-animal',
@@ -52,7 +52,23 @@ return {
         internal = '/test/animals/animal/*/food',
     },
     {
+        external = '/xlat-test/xlat-animals/xlat-animal/*/food/pet/pet',
+        internal = '/test/animals/animal/*/name',
+    },
+    {
+        external = '/xlat-test/xlat-animals/xlat-animal/*/food/*/name',
+        internal = '/test/animals/animal/*/food/*/name',
+    },
+    {
+        external = '/xlat-test/xlat-animals/xlat-animal/*/food/*/type',
+        internal = '/test/animals/animal/*/food/*/type',
+    },
+    {
         external = '/xlat-test/xlat-animals/xlat-animal/*/toys',
         internal = '/test/animals/animal/*/toys',
+    },
+    {
+        external = '/xlat-test/xlat-animals/xlat-animal/*/toys/toy',
+        internal = '/test/animals/animal/*/toys/toy',
     },
 }

--- a/models/xlat_test.xml
+++ b/models/xlat_test.xml
@@ -18,6 +18,7 @@
                         <NODE name="*" help="This is a list of food">
                             <NODE name="name" mode="rw" help="Food name" />
                             <NODE name="type" mode="rw" help="Food type" />
+                            <NODE name="pet" mode="rw" help="Name of animal" />
                         </NODE>
                     </NODE>
                     <NODE name="toys">


### PR DESCRIPTION
If more than a single "*" was included in a translation path, then the translation was not working as expected. This has been fixed.

Also a crash has been reported when translating input paths. This has also been fixed.

When multiple external translation paths map to a single internal path, then only the first external map translation was occurring. This has also been fixed.

The test translation files xlat_test.xml and xlat_test.xlat have been modified to enable more complex tests to be performed.