### PR TITLE
Shutdown apteryx and free instance on lua_close

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -409,6 +409,19 @@ lua_apteryx_valid (lua_State * L)
     return 1;
 }
 
+static int
+luaclose_libapteryx_xml (lua_State *L)
+{
+    sch_instance *api = _get_api (L);
+    if (api)
+    {
+        sch_free (api);
+        _set_api (L, NULL);
+    }
+    apteryx_shutdown ();
+    return 0;
+}
+
 int
 luaopen_libapteryx_xml (lua_State * L)
 {
@@ -427,8 +440,11 @@ luaopen_libapteryx_xml (lua_State * L)
     }
 
     /* Return the Apteryx object on the stack */
-    luaL_newmetatable (L, "apteryx");
+    luaL_newmetatable (L, "apteryx_xml");
     luaL_setfuncs (L, _apteryx_fns, 0);
+    lua_pushcfunction (L, luaclose_libapteryx_xml);
+    lua_setfield (L, -2, "__gc");
+    luaL_setmetatable (L, "apteryx_xml");
     return 1;
 }
 

--- a/test.c
+++ b/test.c
@@ -414,6 +414,9 @@ main (int argc, char *argv[])
     /* Make some random numbers */
     srand (time (NULL));
 
+    /* Need native library for tests */
+    apteryx_init (false);
+
     /* Add tests */
     CU_SuiteInfo *suite = &suites[0];
     while (suite && suite->pName)
@@ -453,5 +456,6 @@ main (int argc, char *argv[])
     CU_set_error_action (CUEA_IGNORE);
     CU_basic_run_tests ();
     CU_cleanup_registry ();
+    apteryx_shutdown ();
     return 0;
 }


### PR DESCRIPTION
The apteryx client library is reference counted
and so needs to be shutdown when the lua instance
is closed. The sch_instance can also be freed.