### PR TITLE
Fix issue with xpath query

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -113,7 +113,8 @@ typedef enum
     SCH_F_SET_NULL              = (1 << 13), /* Set all nodes to NULL */
     SCH_F_FILTER_RDEPTH         = (1 << 14), /* Set filter based on depth value */
 } sch_flags;
-GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char * path, int flags, sch_node ** rschema);
+GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char * path,
+                          int flags, sch_node ** rschema, sch_node ** vschema);
 bool sch_query_to_gnode (sch_instance * instance, sch_node * schema, GNode *parent, const char * query, int flags, int *rflags);
 bool sch_traverse_tree (sch_instance * instance, sch_node * schema, GNode * node, int flags, int rdepth);
 GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char * path, int flags); //DEPRECATED

--- a/schema.c
+++ b/schema.c
@@ -2625,8 +2625,6 @@ _sch_path_to_gnode (sch_instance * instance, sch_node ** rschema, sch_node ** vs
     char *name = NULL;
     char *last_good_schema_name = NULL;
     sch_node *last_good_schema = NULL;
-    _Atomic static sch_node *last_valid_schema = NULL;
-
 
     if (path && path[0] == '/')
     {

--- a/schema.c
+++ b/schema.c
@@ -58,8 +58,6 @@ static __thread char tl_errmsg[BUFSIZ] = {0};
 
 #define READ_BUF_SIZE 512
 
-static sch_node *last_valid_schema = NULL;
-
 typedef struct _sch_instance
 {
     xmlDoc *doc;
@@ -2693,8 +2691,9 @@ _sch_path_to_gnode (sch_instance * instance, sch_node ** rschema, sch_node ** vs
         last_good_schema = schema;
 
         last_good_schema_name = sch_name (last_good_schema);
-        if (last_good_schema && g_strcmp0 (last_good_schema_name, "*") != 0)
-            last_valid_schema = last_good_schema;
+        if (vschema && last_good_schema && g_strcmp0 (last_good_schema_name, "*") != 0)
+            *vschema = last_good_schema;
+
         free (last_good_schema_name);
 
         schema = _sch_node_child (ns, schema, name);
@@ -2819,8 +2818,6 @@ exit:
         *rschema = schema;
     free (name);
     g_free (new_path);
-    if (last_valid_schema && vschema)
-        *vschema = last_valid_schema;
     return rnode;
 }
 

--- a/schema.c
+++ b/schema.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <inttypes.h>
 #include <string.h>
 #include <glib.h>
@@ -2626,6 +2627,8 @@ _sch_path_to_gnode (sch_instance * instance, sch_node ** rschema, sch_node ** vs
     char *name = NULL;
     char *last_good_schema_name = NULL;
     sch_node *last_good_schema = NULL;
+    _Atomic static sch_node *last_valid_schema = NULL;
+
 
     if (path && path[0] == '/')
     {


### PR DESCRIPTION
A "malformed-message" error is returned if an xpath query of the type "/oc-sys:system/processes/process/state/name"
is made, where the xpath consists of a filter to match on the leaf-nodes ("name") associated with multiple list entries("process"). This is because no matching apteryx-xml schema is found for this type of XPATH query.
The proposed change fixes this issue.