### PR TITLE
q2n_append_path: Allow for model in path specifiers

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -3586,6 +3586,25 @@ _sch_gnode_to_json (sch_instance * instance, sch_node * schema, xmlNs *ns, GNode
     return data;
 }
 
+static gchar *
+_model_name (xmlNs *ns, char *model, char *name)
+{
+    gchar *ret;
+    gchar **n_split = g_strsplit (name, ":", 2);
+
+    /* If first part of name is actually the namespace prefix, we don't want to see it */
+    if (g_strv_length (n_split) == 2 && g_strcmp0 (n_split[0], (gchar *) ns->prefix) == 0)
+    {
+        ret = g_strdup_printf ("%s:%s", model, n_split[1]);
+    }
+    else
+    {
+        ret = g_strdup_printf ("%s:%s", model, name);
+    }
+    g_strfreev (n_split);
+    return ret;
+}
+
 json_t *
 sch_gnode_to_json (sch_instance * instance, sch_node * schema, GNode * node, int flags)
 {
@@ -3616,7 +3635,7 @@ sch_gnode_to_json (sch_instance * instance, sch_node * schema, GNode * node, int
             char * model = sch_model (schema, false);
             if (model)
             {
-                name = g_strdup_printf ("%s:%s", model, name);
+                name = _model_name (ns, model, name);
                 json = json_object ();
                 json_object_set_new (json, name, child);
                 free (name);

--- a/schema.c
+++ b/schema.c
@@ -2081,37 +2081,6 @@ q2n_split_params (const char *params, char separator)
 }
 
 static bool
-_check_name (const gchar *name)
-{
-    const gchar *nc;
-    size_t len = strlen (name);
-
-    /* Empty string not valid. */
-    if (len == 0)
-    {
-        return false;
-    }
-
-    /* Single '*' is a wild card */
-    if (len == 1 && name[0] == '*')
-    {
-        return true;
-    }
-    if (!g_ascii_isalpha (name[0]) && name[0] != '_')
-    {
-        return false;
-    }
-    for (nc = name + 1; *nc != '\0'; nc++)
-    {
-        if (!g_ascii_isalnum (*nc) && (*nc != '_') && (*nc != '-') && (*nc != '.'))
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-static bool
 _check_tail (const gchar *tail)
 {
     size_t len = strlen (tail);
@@ -2167,6 +2136,77 @@ add_all_query_nodes (sch_node *schema, GNode *parent, bool config, bool state, i
     return true;
 }
 
+/**
+ * Split a node by ':' character into module and name. Only one ':' allowed, if line is split both
+ * parts must be >0 characters. Return pointers point to original string, ':' is replaced by '\0'.
+ */
+static void
+_split_module_name (char *node, char **name, char **module)
+{
+    char *c_pt;
+    int count_sep = 0;
+    bool on_sep = false;
+    char *first_sep = NULL;
+
+    *module = *name = node;
+    for (c_pt = node; *c_pt != '\0'; c_pt++)
+    {
+        if (*c_pt == ':')
+        {
+            count_sep++;
+            if (first_sep == NULL)
+            {
+                first_sep = c_pt;
+                *first_sep = '\0';
+                on_sep = true;
+            }
+            else
+            {
+                break;
+            }
+        }
+        else if (on_sep)
+        {
+            *name = c_pt;
+            on_sep = false;
+        }
+    }
+
+    /* Clean up. */
+    if (count_sep == 0)
+    {
+        *module = NULL;
+    }
+    else if (count_sep > 1 || on_sep || strlen (*module) == 0 || strlen (*name) == 0)
+    {
+        *module = NULL;
+        *name = node;
+        if (first_sep != NULL)
+        {
+            *first_sep = ':';
+        }
+    }
+}
+
+static bool
+_check_model (char *module, sch_node *schema)
+{
+    bool ret = true;
+    char *model;
+
+    if (module == NULL || strlen (module) == 0)
+    {
+        return ret;
+    }
+    model = sch_model (schema, false);
+    if (model != NULL)
+    {
+        ret = (g_strcmp0 (module, model) == 0);
+    }
+    g_free (model);
+    return ret;
+}
+
 static GNode*
 q2n_append_path (sch_node * schema, GNode *root, const char *path, int flags, int depth, sch_node **rschema, bool expand_non_leaf, bool config, bool nonconfig)
 {
@@ -2178,16 +2218,10 @@ q2n_append_path (sch_node * schema, GNode *root, const char *path, int flags, in
 
     while (*node)
     {
-        char *name = *node;
+        char *name;
+        char *module;
 
-        /* Check characters in name. Must start with A-Za-z_, other characters are A-Za-z_-0-9.
-         * There is an exception for a single '*'
-         */
-        if (!_check_name (name))
-        {
-            g_strfreev (nodes);
-            return NULL;
-        }
+        _split_module_name (*node, &name, &module);
 
         /* Find schema node - since it might be an index node, call it such. */
         index = sch_node_child (schema, name);
@@ -2226,6 +2260,14 @@ q2n_append_path (sch_node * schema, GNode *root, const char *path, int flags, in
         else
         {
             schema = index;
+        }
+
+        /* Should be pointing at a true schema node, check that module matches if specified. */
+        if (!_check_model (module, schema))
+        {
+            ERROR (flags, SCH_E_NOSCHEMANODE, "No model match for %s\n", module);
+            g_strfreev (nodes);
+            return NULL;
         }
 
         /* Create the node if it does not already exist */


### PR DESCRIPTION
Support the format model:path in path specifications. Specifier is split into model/path, and model is checked against schema if present.