### PR TITLE
_sch_path_to_gnode: Fix check for namespace

### DIFF
--- a/models/rpc.lua
+++ b/models/rpc.lua
@@ -48,8 +48,8 @@ local function set_age(path, input)
 end
 
 return {
-    ["/operations/t4:reboot"] = reboot,
-    ["/operations/t4:get-reboot-info"] = get_reboot_info,
+    ["/operations/reboot"] = reboot,
+    ["/operations/get-reboot-info"] = get_reboot_info,
     ["/t4:test/state/reset"] = reset_state,
     ["/t4:test/state/get-last-reset-time"] = get_reset_time,
     ["/t4:test/state/users/*/set-age"] = set_age,

--- a/schema.c
+++ b/schema.c
@@ -2747,7 +2747,7 @@ _sch_path_to_gnode (sch_instance * instance, sch_node ** rschema, xmlNs *ns, con
         }
 
         /* Create node - include namespace node mapping if required */
-        if (depth == 0 || nns || is_proxy)
+        if (depth == 0 || is_proxy)
         {
             if (ns && ns->prefix && !_sch_ns_native (instance, ns))
             {


### PR DESCRIPTION
The test of whether the namespace should be included in the path element was made too liberal, which caused tree lookup errors. This is something that may need to be addressed later, in the meantime, remove the offending code and fix the test cases broken as a result.