### PR TITLE
Fix RFC compliance of identityref value types

### DIFF
--- a/models/test.xml
+++ b/models/test.xml
@@ -67,7 +67,7 @@
       <NODE name="animal" help="This is a list of animals">
         <NODE name="*" help="The animal entry with key name">
           <NODE name="name" mode="rw" help="This is the name of the animal"/>
-          <NODE name="type" mode="rw" default="big" help="This is the type of the animal">
+          <NODE name="type" idref_href="http://test.com/ns/yang/animal-types" idref_prefix="a-types" idref_module="animal-testing-types" mode="rw" default="big" help="This is the type of the animal">
             <VALUE name="big" value="1"/>
             <VALUE name="little" value="2"/>
           </NODE>

--- a/schema.c
+++ b/schema.c
@@ -3587,9 +3587,27 @@ _sch_gnode_to_json (sch_instance * instance, sch_node * schema, xmlNs *ns, GNode
     else if (APTERYX_HAS_VALUE (node))
     {
         char *value = g_strdup (APTERYX_VALUE (node) ? APTERYX_VALUE (node) : "");
+
         if (flags & SCH_F_JSON_TYPES)
         {
             value = sch_translate_to (schema, value);
+        }
+
+        if (value)
+        {
+            /* Check to see if the schema has any identityref information */
+            xmlChar *idref_module = xmlGetProp ((xmlNode *)schema, (const xmlChar *)"idref_module");
+            if (idref_module)
+            {
+                char *temp = value;
+                value = g_strdup_printf ("%s:%s", (char *) idref_module, value);
+                g_free (temp);
+                xmlFree (idref_module);
+            }
+        }
+
+        if (flags & SCH_F_JSON_TYPES)
+        {
             data = encode_json_type (schema, value);
         }
         else


### PR DESCRIPTION
The current code is not compliant to Netconf RFC - RFC6020 https://datatracker.ietf.org/doc/html/rfc6020#section-9.10.5 Also restconf is not compliant to a similar RFC - RFC7951 https://datatracker.ietf.org/doc/html/rfc7951#section-6.8

This change fixes the XML generation tool pyang-apteryx-xml.py to generate enough information so that Netconf and Restconf can set identyref type values with the correct reference information.

A basic model test.xml, was modified to set the new the XML properties on a basic type.