### PR TITLE
Add a flag to control the use of identityref types with values

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -119,6 +119,7 @@ typedef enum
     SCH_F_ADD_MISSING_NULL      = (1 << 12), /* Add missing nodes with NULL values */
     SCH_F_SET_NULL              = (1 << 13), /* Set all nodes to NULL */
     SCH_F_FILTER_RDEPTH         = (1 << 14), /* Set filter based on depth value */
+    SCH_F_IDREF_VALUES          = (1 << 15), /* Expand identityref based values to include type information */
 } sch_flags;
 GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char * path, int flags, sch_node ** rschema);
 bool sch_query_to_gnode (sch_instance * instance, sch_node * schema, GNode *parent, const char * query, int flags, int *rflags);

--- a/schema.c
+++ b/schema.c
@@ -3593,7 +3593,7 @@ _sch_gnode_to_json (sch_instance * instance, sch_node * schema, xmlNs *ns, GNode
             value = sch_translate_to (schema, value);
         }
 
-        if (value)
+        if (value && (flags & SCH_F_IDREF_VALUES))
         {
             /* Check to see if the schema has any identityref information */
             xmlChar *idref_module = xmlGetProp ((xmlNode *)schema, (const xmlChar *)"idref_module");


### PR DESCRIPTION
A new flag SCH_F_IDREF_VALUES has been created to control the addition of identityref information to leaf values.