### PR TITLE
Fix crash with queries to proxy-node schemas

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -3149,6 +3149,12 @@ _sch_traverse_nodes (sch_instance * instance, sch_node * schema, GNode * parent,
             g_free (name);
             name = sch_name (schema);
         }
+        else
+        {
+            /* This can happen if a query is for a field of the proxy schema itself */
+            rc = false;
+            goto exit;
+        }
         depth++;
     }
 


### PR DESCRIPTION
Querying the fields of a model with a proxy node, with the option of report-all causes a crash in apteryx-xml/schema.c in the function _sch_traverse_nodes. This is due to schema being set to NULL while handling the proxy node. This change exits the routine early if schema is set to NULL.