### PR TITLE
Add support for read-only proxy trees

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -95,6 +95,7 @@ bool sch_is_executable (sch_node * node);
 bool sch_is_hidden (sch_node * node);
 bool sch_is_config (sch_node * node);
 bool sch_is_proxy (sch_node * node);
+bool sch_is_read_only_proxy (sch_node * node);
 char *sch_translate_to (sch_node * node, char *value);
 char *sch_translate_from (sch_node * node, char *value);
 bool sch_validate_pattern (sch_node * node, const char *value);
@@ -120,6 +121,7 @@ typedef enum
     SCH_F_SET_NULL              = (1 << 13), /* Set all nodes to NULL */
     SCH_F_FILTER_RDEPTH         = (1 << 14), /* Set filter based on depth value */
     SCH_F_IDREF_VALUES          = (1 << 15), /* Expand identityref based values to include type information */
+    SCH_F_MODIFY_DATA           = (1 << 16), /* The created tree will be used to modify the associated model */
 } sch_flags;
 GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char * path, int flags, sch_node ** rschema);
 bool sch_query_to_gnode (sch_instance * instance, sch_node * schema, GNode *parent, const char * query, int flags, int *rflags);

--- a/models/logical-element.xml
+++ b/models/logical-element.xml
@@ -7,8 +7,14 @@
   <NODE name="logical-elements" help="Allows a device to support multiple logical element (device) instances.">
     <NODE name="logical-element" help="List of logical elements.">
       <NODE name="*" mode="p" help="The logical-element entry with key name">
-        <NODE name="name" mode="rw" help="Device-wide unique identifier for the logical element."/>
-        <NODE name="root" help="Container for mount point."/>
+        <NODE name="name" mode="rw" help="Device-wide unique identifier for the logical element." />
+        <NODE name="root" help="Container for mount point." />
+      </NODE>
+    </NODE>
+    <NODE name="logical-element-ro" help="List of read only logical elements.">
+      <NODE name="*" mode="pr" help="The logical-element entry with key name">
+        <NODE name="name" mode="rw" help="Device-wide unique identifier for the logical element." />
+        <NODE name="root" help="Container for mount point." />
       </NODE>
     </NODE>
   </NODE>


### PR DESCRIPTION
This change allows a remote apteryx database to be mounted at a proxy node as a read only tree.

The logical-element model has been extended to contain a read only logical element for testing purposes.