### PR TITLE
Fixes to condition code

### DIFF
--- a/models/test.xml
+++ b/models/test.xml
@@ -104,7 +104,7 @@
               <REFRESH>Sample REFRESH node</REFRESH>
           </NODE>
           <NODE name="config" >
-            <NODE name="type">
+            <NODE name="type" mode="rw">
               <VALUE name="big" value="1"/>
               <VALUE name="little" value="2"/>
             </NODE>


### PR DESCRIPTION
When processing conditions, the original data in the request must be passed in, but when conditions are applied for REST requests, a recursive descent of the data was taking place, and it was the descending tree that was passed to the condition processing code.

Fix the code that checks existence of a STEP to allow the data to be scanned for the step and that value to be used.

Fix some small memory leaks discovered in testing.