### PR TITLE
Prevent deletion of RO leaf-lists

### DIFF
--- a/models/test.xml
+++ b/models/test.xml
@@ -86,6 +86,9 @@
         <NODE name="minutes" mode="r" help="minutes" range="0..59"/>
         <NODE name="seconds" mode="r" help="seconds" range="0..59"/>
       </NODE>
+      <NODE name="romembers" help="A read-only leaf-list">
+        <NODE name="*" mode="r" help="Member of group"/>
+      </NODE>
     </NODE>
     <NODE name="animals">
       <NODE name="animal" help="This is a list of animals">


### PR DESCRIPTION
The checks that were in the leaf processing code need to also be in the leaf-list section. That is to check the access (rw) and also if the leaves are hidden.
If the leaf-list is ro and the user has asked to delete config-only then we also need to remove the leaves of the leaf-list from the tree otherwise we end up with a strange tree with what looks like values on the leaf-list list node.