### PR TITLE
Fix issues with "with-defaults"

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -129,7 +129,9 @@ typedef enum
 GNode *sch_path_to_gnode (sch_instance * instance, sch_node * schema, const char * path, int flags, sch_node ** rschema);
 bool sch_query_to_gnode (sch_instance * instance, sch_node * schema, GNode *parent, const char * query, int flags,
                          int *rflags, int *param_depth);
-bool sch_traverse_tree (sch_instance * instance, sch_node * schema, GNode * node, int flags, int rdepth);
+bool sch_traverse_tree (sch_instance * instance, sch_node * schema, GNode * node, int flags);
+void sch_add_defaults (sch_instance *instance, sch_node *rschema, GNode **tree, GNode **query,
+                       GNode *rnode, GNode *qnode, int rdepth, int qdepth, int flags);
 GNode *sch_path_to_query (sch_instance * instance, sch_node * schema, const char * path, int flags); //DEPRECATED
 void sch_gnode_sort_children (sch_node * schema, GNode * parent);
 void sch_check_condition (sch_node *node, GNode *root, int flags, char **path, char **condition);


### PR DESCRIPTION
The netconf code for processing "with-defaults" has been aligned to be similar to the existing restconf code. In particular netconf is now only passing the part of the tree that needs to have the "with-defaults" modifications made to it.

A new routine has been added to detect if a query is only for leaf fields. In that case when "with-defaults" is set to report-all, there is no need to check if we need to add additional defaults.