### PR TITLE
Better handle empty json lists

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
-      run: sudo apt-get install -y build-essential libglib2.0-dev libxml2-dev libcunit1-dev libjansson-dev liblua5.3-dev valgrind
+      run: |
+        sudo apt update
+        sudo apt-get install -y build-essential libglib2.0-dev libxml2-dev libcunit1-dev libjansson-dev liblua5.3-dev valgrind
     - name: Clone apteryx
       uses: actions/checkout@v2
       with:

--- a/schema.c
+++ b/schema.c
@@ -4192,9 +4192,14 @@ _sch_json_to_gnode (sch_instance * instance, sch_node * schema, xmlNs *ns,
     /* LEAF-LIST */
     if (sch_is_leaf_list (schema) && json_is_array (json))
     {
-        depth++;
         tree = node = APTERYX_NODE (NULL, g_strdup (name));
         schema = sch_node_child_first (schema);
+        if (json_array_size(json) == 0 )
+        {
+            DEBUG (flags, "%*s%s%s = (null)\n", depth * 2, " ", depth ? "" : "/", name);
+            node = APTERYX_NODE (tree, NULL);
+        }
+        depth++;
         json_array_foreach (json, index, child)
         {
             value = decode_json_type (child);
@@ -4224,6 +4229,11 @@ _sch_json_to_gnode (sch_instance * instance, sch_node * schema, xmlNs *ns,
         depth++;
         tree = node = APTERYX_NODE (NULL, g_strdup (name));
         schema = sch_node_child_first (schema);
+        if (json_array_size(json) == 0 )
+        {
+            node = APTERYX_NODE (tree, NULL);
+            DEBUG (flags, "%*s%s\n", depth * 2, " ", "(null)");
+        }
         json_array_foreach (json, index, child)
         {
             json_t *subchild;


### PR DESCRIPTION
We now detect an empty list and append a (null) to the list node. This is better behaviour than setting the parent node value to the list name. It also ensures we cannot create an empty list in restconf if there is already a list present.