### PR TITLE
Avoid deprecated libxml2 function

### DIFF
--- a/schema.c
+++ b/schema.c
@@ -248,7 +248,11 @@ load_schema_files (GList ** files, const char *path)
                 new_item->d_name = g_strdup (ep->d_name);
                 if (fnmatch ("*.map", ep->d_name, FNM_PATHNAME) != 0)
                 {
+#if LIBXML_VERSION >= 21400
+                    new_item->doc_new = xmlReadFile (new_item->filename, NULL, XML_PARSE_UNZIP);
+#else   /* LibXML < 2.14.0 */
                     new_item->doc_new = xmlParseFile (new_item->filename);
+#endif  /* LIBXML_VERSION */
                     if (new_item->doc_new == NULL)
                     {
                         syslog (LOG_ERR, "XML: failed to parse \"%s\"", new_item->filename);


### PR DESCRIPTION
In LibXML 2.14.0, xmlParseFile was deprecated in favour of xmlReadFile. The new function allows specification of parser options as defined by the xmlParserOption struct:
https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/include/libxml/parser.h#L1678

XML_PARSE_UNZIP is currently enabled by default in xmlReadFile but may be subject to change. Parsing Gzip-compressed files is no longer supported by xmlParseFile.

Support maintained with earlier versions of LibXML2 for unit testing.