### PR TITLE
Add more union related functionality to yang to xml converter

### DIFF
--- a/pyang-apteryx-xml.py
+++ b/pyang-apteryx-xml.py
@@ -24,6 +24,7 @@ Output paths in Apteryx XML file format
 # all code submitted there is done so under GPL
 
 import io
+import re
 import sys
 import os
 import optparse
@@ -725,12 +726,25 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
         if ntype.arg in ["int8", "int16", "int32", "uint8", "uint16", "uint32"]:
             range = ntype.search_one("range")
             if range is not None:
-                limits = range.arg.replace('..', '.').split('.')
-                l0 = int(limits[0])
-                l1 = int(limits[1])
-                if l0 > l1:
-                    l1, l0 = l0, l1
-                rfr = RegexForRange(l0, l1)
+                # Handles split ranges like "0 | 10..525600"
+                range_parts = [p.strip() for p in range.arg.split('|')]
+                rfr_list = []
+                for part in range_parts:
+                    if '..' in part:
+                        limits = part.split('..')
+                        l0 = int(limits[0].strip())
+                        l1 = int(limits[1].strip())
+                        if l0 > l1:
+                            l1, l0 = l0, l1
+                        rfr_list.append(f"{RegexForRange(l0, l1)}")
+                    else:
+                        val = int(part.strip())
+                        rfr_list.append(f"{RegexForRange(val, val)}")
+                if len(rfr_list) == 1:
+                    patt = rfr_list[0]
+                else:
+                    patt = '|'.join(rfr_list)
+                return patt
             elif ntype.arg == "int8":
                 rfr = RegexForRange(-128, 127)
             elif ntype.arg == "int16":
@@ -761,6 +775,13 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
 
                     if npatt:
                         patterns.append(f"({npatt.arg})")
+                    elif ut.arg == "enumeration":
+                        enum_names = []
+                        for enum in ut.substmts:
+                            if enum.keyword == "enum":
+                                enum_names.append(re.escape(enum.arg))
+                        if enum_names:
+                            patterns.append('(' + '|'.join(enum_names) + ')')
                     else:
                         utpatt = self.type_to_pattern(ut)
                         if utpatt is not None:

--- a/pyang-apteryx-xml.py
+++ b/pyang-apteryx-xml.py
@@ -762,6 +762,46 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
             return patt
         return None
 
+    def union_enum_values(self, ntype, res, ns):
+        """Generate VALUE elements for enumeration types within a union."""
+        if ntype.arg != 'union':
+            return
+        uniontypes = ntype.search('type')
+        for uniontype in uniontypes:
+            ut = uniontype
+            if uniontype.i_typedef:
+                ut = uniontype.i_typedef.search_one("type")
+            if ut is not None:
+                if ut.arg == "enumeration":
+                    count = 0
+                    for enum in ut.substmts:
+                        if enum.keyword != "enum":
+                            continue
+                        value = etree.SubElement(res, "{" + ns.arg + "}VALUE")
+                        value.attrib = OrderedDict()
+                        value.attrib["name"] = enum.arg
+                        val = enum.search_one('value')
+                        if val is not None:
+                            value.attrib["value"] = val.arg
+                            try:
+                                val_int = int(val.arg)
+                            except ValueError:
+                                val_int = None
+                            if val_int is not None:
+                                count = val_int
+                        else:
+                            if self.enum_name:
+                                value.attrib["value"] = value.attrib["name"]
+                            else:
+                                value.attrib["value"] = str(count)
+                        count = count + 1
+                        descr = enum.search_one('description')
+                        if descr is not None:
+                            descr.arg = descr.arg.replace('\r', ' ').replace('\n', ' ')
+                            value.attrib["help"] = descr.arg
+                elif ut.arg == "union":
+                    self.union_enum_values(ut, res, ns)
+
     def union_pattern (self,ntype):
         patterns = [] 
         if ntype.arg == 'union': 
@@ -943,5 +983,6 @@ class ApteryxXMLPlugin(plugin.PyangPlugin):
                 patterns = self.union_pattern(ntype)
                 if len(patterns) > 0:
                     res.attrib["pattern"] = '|'.join(patterns)
+                self.union_enum_values(ntype, res, ns)
 
         return res, module, path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,14 +57,18 @@ def assert_xml_equal(actual, expected):
         raise AssertionError(f"XML mismatch:\n{diff}")
 
 
-def pyang(yang, format="tree"):
+def pyang(yang, format="tree", extra_args=None):
     output = ""
     with tempfile.NamedTemporaryFile(dir="/tmp", delete=False, mode="w", suffix=".yang") as tmp_file:
         tmp_file.write(yang)
         tmp_file.flush()
         yang_file = tmp_file.name
+        cmd = ["pyang", "--plugindir", Path(__file__).resolve().parent.parent, "-f", format]
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.append(str(yang_file))
         result = subprocess.run(
-            ["pyang", "--plugindir", Path(__file__).resolve().parent.parent, "-f", format, str(yang_file)],
+            cmd,
             capture_output=True,
             text=True
         )

--- a/tests/test_pyang-apteryx-xml.py
+++ b/tests/test_pyang-apteryx-xml.py
@@ -201,6 +201,28 @@ def test_xml_union_union_strings():
     output = pyang(yang, format="apteryx-xml")
     assert_xml_equal(output, expected)
 
+def test_xml_enum():
+    yang = Module("example", children=[Leaf("test", "enumeration", enumeration=["up", "down", "testing"])]).render()
+    print(yang)
+    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "children": [
+        {"tag": "VALUE", "name": "up", "value": "0"},
+        {"tag": "VALUE", "name": "down", "value": "1"},
+        {"tag": "VALUE", "name": "testing", "value": "2"},
+    ]}])
+    output = pyang(yang, format="apteryx-xml")
+    assert_xml_equal(output, expected)
+
+def test_xml_enum_names():
+    yang = Module("example", children=[Leaf("test", "enumeration", enumeration=["up", "down", "testing"])]).render()
+    print(yang)
+    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "children": [
+        {"tag": "VALUE", "name": "up", "value": "up"},
+        {"tag": "VALUE", "name": "down", "value": "down"},
+        {"tag": "VALUE", "name": "testing", "value": "testing"},
+    ]}])
+    output = pyang(yang, format="apteryx-xml", extra_args=["--enum-name"])
+    assert_xml_equal(output, expected)
+
 def test_xml_union_range_enum():
     yang = Module("example", children=[Leaf("test", "union", union_types=[
             'uint16 { range "0 | 1..35537 | 35539..35540"; }',

--- a/tests/test_pyang-apteryx-xml.py
+++ b/tests/test_pyang-apteryx-xml.py
@@ -181,7 +181,6 @@ def test_xml_union_int():
     output = pyang(yang, format="apteryx-xml")
     assert_xml_equal(output, expected)
 
-
 def test_xml_union_union_strings():
     yang = Module("example", children=[
         Typedef("type1", "union", union_types=[
@@ -199,5 +198,14 @@ def test_xml_union_union_strings():
     ]).render()
     print(yang)
     expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "pattern": "((1|2)|(3|4))|((5|6)|(7|8))"}])
+    output = pyang(yang, format="apteryx-xml")
+    assert_xml_equal(output, expected)
+
+def test_xml_union_range_enum():
+    yang = Module("example", children=[Leaf("test", "union", union_types=[
+            'uint16 { range "0 | 1..35537 | 35539..35540"; }',
+            'enumeration { enum  none { description "do not use this feature"; } } '])]).render()
+    print(yang)
+    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "pattern": "(0|([1-9][0-9]{0,3}|[12][0-9]{4}|3[0-4][0-9]{3}|35[0-4][0-9]{2}|355[0-2][0-9]|3553[0-7])|355(39|40))|(none)"}])
     output = pyang(yang, format="apteryx-xml")
     assert_xml_equal(output, expected)

--- a/tests/test_pyang-apteryx-xml.py
+++ b/tests/test_pyang-apteryx-xml.py
@@ -228,6 +228,15 @@ def test_xml_union_range_enum():
             'uint16 { range "0 | 1..35537 | 35539..35540"; }',
             'enumeration { enum  none { description "do not use this feature"; } } '])]).render()
     print(yang)
-    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "pattern": "(0|([1-9][0-9]{0,3}|[12][0-9]{4}|3[0-4][0-9]{3}|35[0-4][0-9]{2}|355[0-2][0-9]|3553[0-7])|355(39|40))|(none)"}])
+    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "pattern": "(0|([1-9][0-9]{0,3}|[12][0-9]{4}|3[0-4][0-9]{3}|35[0-4][0-9]{2}|355[0-2][0-9]|3553[0-7])|355(39|40))|(none)", "children":[{"tag": "VALUE", "name": "none", "value": "0", "help": "do not use this feature"}]}])
     output = pyang(yang, format="apteryx-xml")
+    assert_xml_equal(output, expected)
+
+def test_xml_union_range_enum_names():
+    yang = Module("example", children=[Leaf("test", "union", union_types=[
+            'uint16 { range "0 | 1..35537 | 35539..35540"; }',
+            'enumeration { enum  none { description "do not use this feature"; } } '])]).render()
+    print(yang)
+    expected = dict_to_xml("example", [{"name": "test", "mode": "rw", "pattern": "(0|([1-9][0-9]{0,3}|[12][0-9]{4}|3[0-4][0-9]{3}|35[0-4][0-9]{2}|355[0-2][0-9]|3553[0-7])|355(39|40))|(none)", "children":[{"tag": "VALUE", "name": "none", "value": "none", "help": "do not use this feature"}]}])
+    output = pyang(yang, format="apteryx-xml", extra_args=["--enum-name"])
     assert_xml_equal(output, expected)


### PR DESCRIPTION
I'm converting an xml file that has a range as well as a named value in a number of fields. I've implemented these in the yang file as a range and a union. The first patch in the series handles putting these in the pattern. The second patch adds some tests for the existing enum handling including the enum-name option. The third patch adds value nodes for the enums in a union to the XML. This was suggested by copilot, but not sure if it is needed.