### PR TITLE
Removed white space from range variables

### DIFF
--- a/models/test.xml
+++ b/models/test.xml
@@ -17,7 +17,7 @@
       </NODE>
       <NODE name="empty" help="an empty container">
       </NODE>
-      <NODE name="priority" mode="rw" help="integer" range="-5..-1|1..5|99"/>
+      <NODE name="priority" mode="rw" help="integer" range="-5..-1 | 1..5 | 99"/>
       <NODE name="writeonly" mode="w" help="A write only field"/>
       <NODE name="readonly" mode="r" default="yes" help="A read only field">
         <VALUE name="yes" value="0" help="This is read only"/>

--- a/schema.c
+++ b/schema.c
@@ -2044,6 +2044,18 @@ _sch_validate_pattern (sch_node * node, const char *value, int flags)
     char *range = (char *) xmlGetProp (node, (xmlChar *) "range");
     if (range)
     {
+        /* Remove whitespaces for range value */
+        char *dst = range;
+        char *src = range;
+
+        while (*src) {
+            if (!isspace((unsigned char)*src)) {
+                *dst++ = *src;
+            }
+            src++;
+        }
+        *dst = '\0';
+
         bool vint_neg, min_neg, max_neg;
         uint64_t vint, min, max;
 


### PR DESCRIPTION
This commit parse the range variable and remove all whitespace to follow the XML format.