### PR TITLE
Helper function sch_name_no_ns

### DIFF
--- a/apteryx-xml.h
+++ b/apteryx-xml.h
@@ -79,6 +79,7 @@ sch_ns *sch_lookup_ns (sch_instance * instance, sch_node *schema, const char *na
 sch_node *sch_ns_node_child (sch_ns *ns, sch_node * parent, const char *child);
 
 char *sch_name (sch_node * node);
+char *sch_name_no_ns (sch_node * node);
 char *sch_model (sch_node * node, bool ignore_ancestors);
 char *sch_organization (sch_node * node);
 char *sch_version (sch_node * node);

--- a/schema.c
+++ b/schema.c
@@ -1568,19 +1568,31 @@ sch_preorder_next(sch_node *current, sch_node *root) {
     return next == root ? NULL : next;
 }
 
-char *
-sch_name (sch_node * node)
+static char *
+_sch_name (sch_node * node, bool add_ns)
 {
     xmlNode *n = (xmlNode *) node;
     sch_instance *instance = n ? n->doc->_private : NULL;
     char *name = (char *) xmlGetProp (n, (xmlChar *) "name");
-    if (!_sch_ns_native (instance, n->ns) && !sch_node_parent (sch_node_parent (node)))
+    if (!_sch_ns_native (instance, n->ns) && !sch_node_parent (sch_node_parent (node)) && add_ns)
     {
         char *_name = g_strdup_printf ("%s:%s", n->ns->prefix, name);
         free (name);
         name = _name;
     }
     return name;
+}
+
+char *
+sch_name (sch_node * node)
+{
+    return _sch_name (node, true);
+}
+
+char *
+sch_name_no_ns (sch_node *node)
+{
+    return _sch_name (node, false);
 }
 
 /* Ignoring ancestors allows checking that this is a node with the model data directly attached. */


### PR DESCRIPTION
Add a helper function that returns the node name without the namespace prefix.